### PR TITLE
Show nothing on desktop when widget fails to retrieve information

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -37,9 +37,7 @@ const cheerio = require("cheerio");
 
 axios.get(`https://github.com/${options.user}`)
 	.then(generate)
-	.catch(function (err) {
-		return
-	});
+	.catch(() => {});
 
 function generate(res) {
 	console.log(`<svg id="github-activity" width="${53 * options.size}" height="${7 * (options.size)}">`);

--- a/src/generate.js
+++ b/src/generate.js
@@ -37,7 +37,9 @@ const cheerio = require("cheerio");
 
 axios.get(`https://github.com/${options.user}`)
 	.then(generate)
-	.catch(console.error);
+	.catch(function (err) {
+		return
+	});
 
 function generate(res) {
 	console.log(`<svg id="github-activity" width="${53 * options.size}" height="${7 * (options.size)}">`);


### PR DESCRIPTION
This prevents the widget from displaying error messages on the desktop when information cannot be retrieved from the GitHub account. 

Feel free to reject this if the error-displaying is intended behavior. 